### PR TITLE
Make the article guidelines part of the journal aims.

### DIFF
--- a/aimsAndScope.md
+++ b/aimsAndScope.md
@@ -18,5 +18,5 @@ The journal has the following open science ambitions:
   stated in the paper must be accessible without the need for registration, login or agreement
   with license terms other than Creative Commons licenses for data and text and OSI-approved
   Open Source Licenses for software.
-* for any scripts or software, the source code must be provided.
+* For any scripts or software, the source code must be provided.
 


### PR DESCRIPTION
Hi all, our article guidelines are pretty specific about it, but after rejecting yet another potentially interesting article because the authors made no effort to make their work _fully reproducible_, I decided we have to improve our website further. This patch focuses on the "Aims and Scope" page, where I here added a section on our Open Science Aims. To me, Journal of Cheminformatics is a journal where we want to promote Open Science, not just publish Open Access. Of course, the author guidelines already reflected that, and I only copy/pasted the lead paragraph of the "Research" article type guidelines into this page, and made it bullet points.

Please note a tweak I made to the last point, which now reads as "for any scripts or software"... when an article writes, "we used R to", I see no reason why that R script should not be included. Apparently, "software" was too specific.

Protocol: everyone, please use the [review method of GitHub](https://help.github.com/articles/reviewing-proposed-changes-in-a-pull-request/) to provide your feedback.